### PR TITLE
ADD: cgroupsv2 support for the docker executor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,21 @@
-Release Notes - Mesos/ClusterD
--------------------------------------------
+Release Notes - Clusterd
+-----------------------------------------------
 This master branch contains the following changes:
 
-  * Docker Containerize now supports CNI.
+  * Docker Containerizer now supports CGroupsV2. It will be enabled by the Mesos Agent flag "--enable_cgroupv2". At the current state, it will
+  break the mesos containerizer.
+
+Release Notes - Clusterd - Version 1.11.0-0.3.0
+-----------------------------------------------
+This release contains the following highlights:
+
+  * Docker Containerizer now supports CNI.
+  * Add CNI support for the Docker Executor.
+  * Fix random SlaveRecoveryTest.PingTimeoutDuringRecovery test failure.
+  * Fix Blkio isolator. handled missing CFQ statistics.
+  * Fix mesos-tidy build with new gRPC version.
+  * Upgraded grpc to 1.11.1
+  * Add s390x support
 
 
 Release Notes - Mesos - Version 1.11.0

--- a/src/docker/docker.hpp
+++ b/src/docker/docker.hpp
@@ -62,6 +62,7 @@ public:
       const std::string& path,
       const std::string& socket,
       bool validate = true,
+      bool enableCgroupsV2 = false,
       const Option<JSON::Object>& config = None());
 
   virtual ~Docker() {}

--- a/src/docker/executor.cpp
+++ b/src/docker/executor.cpp
@@ -108,6 +108,7 @@ public:
       const map<string, string>& taskEnvironment,
       const Option<ContainerDNSInfo>& defaultContainerDNS,
       bool cgroupsEnableCfs,
+      bool enableCgroupsV2,
       const string& network_cni_plugins_dir,
       const string& network_cni_config_dir)
     : ProcessBase(ID::generate("docker-executor")),
@@ -124,6 +125,7 @@ public:
       taskEnvironment(taskEnvironment),
       defaultContainerDNS(defaultContainerDNS),
       cgroupsEnableCfs(cgroupsEnableCfs),
+      enableCgroupsV2(enableCgroupsV2),
       network_cni_plugins_dir(network_cni_plugins_dir),
       network_cni_config_dir(network_cni_config_dir),
       stop(Nothing()),
@@ -1129,6 +1131,7 @@ private:
   map<string, string> taskEnvironment;
   Option<ContainerDNSInfo> defaultContainerDNS;
   bool cgroupsEnableCfs;
+  bool enableCgroupsV2;
   string network_cni_plugins_dir;
   string network_cni_config_dir;
   string containerId;
@@ -1157,6 +1160,7 @@ DockerExecutor::DockerExecutor(
     const map<string, string>& taskEnvironment,
     const Option<ContainerDNSInfo>& defaultContainerDNS,
     bool cgroupsEnableCfs,
+    bool enableCgroupsV2,
     const string& network_cni_plugins_dir,
     const string& network_cni_config_dir)
 {
@@ -1170,6 +1174,7 @@ DockerExecutor::DockerExecutor(
       taskEnvironment,
       defaultContainerDNS,
       cgroupsEnableCfs,
+      enableCgroupsV2,
       network_cni_plugins_dir,
       network_cni_config_dir));
 

--- a/src/docker/executor.hpp
+++ b/src/docker/executor.hpp
@@ -91,6 +91,11 @@ struct Flags : public virtual mesos::internal::logging::Flags
         "via the CFS bandwidth limiting subfeature.\n",
         false);
 
+    add(&Flags::enable_cgroupsv2,
+        "enable_cgroupsv2",
+        "Enable CGroupsV2 Support (ALPHA).",
+        false);        
+
     add(&Flags::network_cni_plugins_dir,
         "network_cni_plugins_dir",
         "A search path for CNI plugin binaries. The docker executer\n"
@@ -118,6 +123,7 @@ struct Flags : public virtual mesos::internal::logging::Flags
   Option<std::string> network_cni_config_dir;
 
   bool cgroups_enable_cfs;
+  bool enable_cgroupsv2;
 
   // TODO(alexr): Remove this after the deprecation cycle (started in 1.0).
   Option<Duration> stop_timeout;
@@ -140,6 +146,7 @@ public:
       const std::map<std::string, std::string>& taskEnvironment,
       const Option<ContainerDNSInfo>& defaultContainerDNS,
       bool cgroupsEnableCfs,
+      bool enableCgroupsV2,
       const std::string& network_cni_plugins_dir,
       const std::string& network_cni_config_dir);
 

--- a/src/launcher/docker_executor.cpp
+++ b/src/launcher/docker_executor.cpp
@@ -246,6 +246,7 @@ int main(int argc, char** argv)
           taskEnvironment,
           defaultContainerDNS,
           flags.cgroups_enable_cfs,
+          flags.enable_cgroupsv2,
           flags.network_cni_plugins_dir.get(),
           flags.network_cni_config_dir.get()));
 

--- a/src/linux/cgroups.cpp
+++ b/src/linux/cgroups.cpp
@@ -365,26 +365,28 @@ Try<string> prepare(
     // Attempt to mount the hierarchy ourselves.
     hierarchy = path::join(baseHierarchy, subsystem);
 
-    if (os::exists(hierarchy.get())) {
-      // The path specified by the given hierarchy already exists in
-      // the file system. We try to remove it if it is an empty
-      // directory. This will helps us better deal with slave restarts
-      // since we won't need to manually remove the directory.
-      Try<Nothing> rmdir = os::rmdir(hierarchy.get(), false);
-      if (rmdir.isError()) {
+    if (!cgroups::cgroupsv2()) {
+      if (os::exists(hierarchy.get())) {
+        // The path specified by the given hierarchy already exists in
+        // the file system. We try to remove it if it is an empty
+        // directory. This will helps us better deal with slave restarts
+        // since we won't need to manually remove the directory.
+        Try<Nothing> rmdir = os::rmdir(hierarchy.get(), false);
+        if (rmdir.isError()) {
+          return Error(
+              "Failed to mount cgroups hierarchy at '" + hierarchy.get() +
+              "' because we could not remove the existing directory: " +
+              rmdir.error());
+        }
+      }
+
+      // Mount the subsystem.
+      Try<Nothing> mount = cgroups::mount(hierarchy.get(), subsystem);
+      if (mount.isError()) {
         return Error(
             "Failed to mount cgroups hierarchy at '" + hierarchy.get() +
-            "' because we could not remove the existing directory: " +
-            rmdir.error());
+            "': " + mount.error());
       }
-    }
-
-    // Mount the subsystem.
-    Try<Nothing> mount = cgroups::mount(hierarchy.get(), subsystem);
-    if (mount.isError()) {
-      return Error(
-          "Failed to mount cgroups hierarchy at '" + hierarchy.get() +
-          "': " + mount.error());
     }
   }
 
@@ -441,6 +443,17 @@ bool enabled()
 {
   return os::exists("/proc/cgroups");
 }
+
+bool cgroupsv2()
+{
+  // /sys/fs/cgroup/cpu does not exist in cgroupsv2
+  if (!os::exists("/sys/fs/cgroup/cpu")) {
+    return true;
+  }
+
+  return false;
+}
+
 
 
 Try<set<string>> hierarchies()
@@ -589,7 +602,7 @@ Try<set<string>> subsystems(const string& hierarchy)
   // Check if hierarchy is a mount point of type cgroup.
   Option<fs::MountTable::Entry> hierarchyEntry;
   foreach (const fs::MountTable::Entry& entry, table->entries) {
-    if (entry.type == "cgroup") {
+    if (entry.type == "cgroup" || entry.type == "cgroup2") {
       Result<string> dirAbsPath = os::realpath(entry.dir);
       if (!dirAbsPath.isSome()) {
         return Error(

--- a/src/linux/cgroups.hpp
+++ b/src/linux/cgroups.hpp
@@ -91,6 +91,12 @@ Try<Nothing> verify(
 bool enabled();
 
 
+// Check whether cgroupsv2 module is enabled on the current machine.
+// @return  True if cgroupsv2 module is enabled.
+//          False if cgroupsv2 module is not available.
+bool cgroupsv2();
+
+
 // Return the currently active hierarchies.
 // @return  A set of active hierarchy paths (e.g., '/cgroup').
 //          Error if unexpected happens.
@@ -115,7 +121,6 @@ Result<std::string> hierarchy(const std::string& subsystems);
 //          False if any of the given subsystems is not enabled.
 //          Error if something unexpected happens.
 Try<bool> enabled(const std::string& subsystems);
-
 
 // Return true if any of the given subsystems is currently attached to a
 // hierarchy.

--- a/src/linux/systemd.cpp
+++ b/src/linux/systemd.cpp
@@ -59,6 +59,11 @@ Flags::Flags()
       "cgroups_hierarchy",
       "The path to the cgroups hierarchy root\n",
       "/sys/fs/cgroup");
+
+  add(&Flags::enable_cgroupsv2,
+      "enable_cgroupsv2",
+      "Enable CGroupsV2 Support (ALPHA).",
+      false);      
 }
 
 
@@ -178,15 +183,17 @@ Try<Nothing> initialize(const Flags& flags)
                  "': " + start.error());
   }
 
-  // Now the `MESOS_EXECUTORS_SLICE` is ready for us to assign any pids. We can
-  // verify that our cgroups assignments will work by testing the hierarchy.
-  Try<Nothing> cgroupsVerify = cgroups::verify(
-      systemd::hierarchy(),
-      mesos::MESOS_EXECUTORS_SLICE);
-
-  if (cgroupsVerify.isError()) {
-    return Error("Failed to locate systemd cgroups hierarchy: " +
-                 cgroupsVerify.error());
+  // cgroupsv2 does not have a systemd cgroups hierarchy
+  if (!systemd_flags->enable_cgroupsv2) {
+    // Now the `MESOS_EXECUTORS_SLICE` is ready for us to assign any pids. We can
+    // verify that our cgroups assignments will work by testing the hierarchy.
+    Try<Nothing> cgroupsVerify = cgroups::verify(
+        systemd::hierarchy(),
+        mesos::MESOS_EXECUTORS_SLICE);
+      if (cgroupsVerify.isError()) {
+      return Error("Failed to locate systemd cgroups hierarchy: " +
+                   cgroupsVerify.error());
+    }
   }
 
   initialized->done();
@@ -276,6 +283,9 @@ Path runtimeDirectory()
 
 Path hierarchy()
 {
+  if (flags().enable_cgroupsv2) {
+    return Path(flags().cgroups_hierarchy);
+  }
   return Path(path::join(flags().cgroups_hierarchy, "systemd"));
 }
 

--- a/src/linux/systemd.hpp
+++ b/src/linux/systemd.hpp
@@ -128,6 +128,7 @@ public:
   bool enabled;
   std::string runtime_directory;
   std::string cgroups_hierarchy;
+  bool enable_cgroupsv2;
 };
 
 

--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -185,6 +185,7 @@ Try<DockerContainerizer*> DockerContainerizer::create(
       flags.docker,
       flags.docker_socket,
       true,
+      flags.enable_cgroupsv2,
       flags.docker_config);
 
   if (create.isError()) {

--- a/src/slave/containerizer/mesos/linux_launcher.cpp
+++ b/src/slave/containerizer/mesos/linux_launcher.cpp
@@ -125,15 +125,17 @@ Try<Launcher*> LinuxLauncher::create(const Flags& flags)
   }
 
   // Ensure that no other subsystem is attached to the freezer hierarchy.
-  Try<set<string>> subsystems = cgroups::subsystems(freezerHierarchy.get());
-  if (subsystems.isError()) {
-    return Error(
-        "Failed to get the list of attached subsystems for hierarchy " +
-        freezerHierarchy.get());
-  } else if (subsystems->size() != 1) {
-    return Error(
-        "Unexpected subsystems found attached to the hierarchy " +
-        freezerHierarchy.get());
+  if (!flags.enable_cgroupsv2) {
+    Try<set<string>> subsystems = cgroups::subsystems(freezerHierarchy.get());
+    if (subsystems.isError()) {
+      return Error(
+          "Failed to get the list of attached subsystems for hierarchy " +
+          freezerHierarchy.get());
+    } else if (subsystems->size() != 1) {
+      return Error(
+          "Unexpected subsystems found attached to the hierarchy " +
+          freezerHierarchy.get());
+    }
   }
 
   LOG(INFO) << "Using " << freezerHierarchy.get()

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -375,6 +375,12 @@ mesos::internal::slave::Flags::Flags()
       "environment or find hadoop on `PATH`)");
 
 #ifndef __WINDOWS__
+
+  add(&Flags::enable_cgroupsv2,
+      "enable_cgroupsv2",
+      "Enable CGroupsV2 Support (ALPHA).",
+      false);
+
   add(&Flags::switch_user,
       "switch_user",
       "If set to `true`, the agent will attempt to run tasks as\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -76,6 +76,7 @@ public:
   size_t max_completed_executors_per_framework;
 
 #ifndef __WINDOWS__
+  bool enable_cgroupsv2;
   bool switch_user;
   Option<std::string> volume_gid_range;
 #endif // __WINDOWS__

--- a/src/slave/main.cpp
+++ b/src/slave/main.cpp
@@ -487,10 +487,16 @@ int main(int argc, char** argv)
   if (flags.systemd_enable_support && systemd::exists()) {
     LOG(INFO) << "Initializing systemd state";
 
+    // under cgroupsv2, systemd does not have it's own cgroups hierarchy.
+    if (flags.enable_cgroupsv2) {
+      flags.cgroups_hierarchy = "/sys/fs/cgroup";
+    }
+
     systemd::Flags systemdFlags;
     systemdFlags.enabled = flags.systemd_enable_support;
     systemdFlags.runtime_directory = flags.systemd_runtime_directory;
     systemdFlags.cgroups_hierarchy = flags.cgroups_hierarchy;
+    systemdFlags.enable_cgroupsv2 = flags.enable_cgroupsv2;
 
     Try<Nothing> initialize = systemd::initialize(systemdFlags);
     if (initialize.isError()) {


### PR DESCRIPTION
These PR will add a new mesos agent flag to enable support for  cgroupsv2. If it's set, it will disable the systemd cgroupsv1 check of the docker containerizer. Since cgroupsv2 does not have these systemd group anymore, these check makes no sense.

These PR will also disable the same checks of the mesos contrainerizer but only to prevent a crash of the mesos agent if `enable_cgroupsv2` flag is set and the mesos containerizer is configured.

**These PR will break the mesos containerizer if the flag is set to `true`. The cgroupsv2 support of the mesos contrainerizer will come in a future PR.**
